### PR TITLE
[TEST] Fix KettleInit failure

### DIFF
--- a/kettle-sdk-database-plugin/pom.xml
+++ b/kettle-sdk-database-plugin/pom.xml
@@ -70,4 +70,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>xerces</groupId>
+        <artifactId>xercesImpl</artifactId>
+        <version>2.8.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>

--- a/kettle-sdk-jobentry-plugin/pom.xml
+++ b/kettle-sdk-jobentry-plugin/pom.xml
@@ -79,4 +79,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>xerces</groupId>
+        <artifactId>xercesImpl</artifactId>
+        <version>2.8.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>

--- a/kettle-sdk-partitioner-plugin/pom.xml
+++ b/kettle-sdk-partitioner-plugin/pom.xml
@@ -79,4 +79,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>xerces</groupId>
+        <artifactId>xercesImpl</artifactId>
+        <version>2.8.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>

--- a/kettle-sdk-step-plugin/pom.xml
+++ b/kettle-sdk-step-plugin/pom.xml
@@ -79,4 +79,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>xerces</groupId>
+        <artifactId>xercesImpl</artifactId>
+        <version>2.8.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>


### PR DESCRIPTION
Xerces dependency was incorrectly using older version inheritied from commons-dbcp via pentaho-metadata dependency.