### PR TITLE
 [PPP-4271] - Fixed Use of Vulnerable Component: xercesImpl-2.11.0 and xercesImpl-2.9.1 (CVE-2013-4002 | CVE-2012-0881 | CVE-2009-2625 | sonatype-2017-0348)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ build-res/module-scripts/
 *.iml
 *.prefs
 *.classpath
+.idea/

--- a/kettle-sdk-database-plugin/pom.xml
+++ b/kettle-sdk-database-plugin/pom.xml
@@ -13,15 +13,6 @@
   <properties>
     <csvjdbc.version>1.0.29</csvjdbc.version>
   </properties>
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>xerces</groupId>
-        <artifactId>xercesImpl</artifactId>
-        <version>2.8.1</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>pentaho-kettle</groupId>

--- a/kettle-sdk-embedding-samples/pom.xml
+++ b/kettle-sdk-embedding-samples/pom.xml
@@ -60,7 +60,6 @@
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
-      <version>2.9.1</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/kettle-sdk-jobentry-plugin/pom.xml
+++ b/kettle-sdk-jobentry-plugin/pom.xml
@@ -10,15 +10,6 @@
   <artifactId>kettle-sdk-jobentry-plugin</artifactId>
   <version>8.3.0.0-SNAPSHOT</version>
   <name>Pentaho Data Integration SDK Job Entry Plugin</name>
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>xerces</groupId>
-        <artifactId>xercesImpl</artifactId>
-        <version>2.8.1</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.pentaho</groupId>

--- a/kettle-sdk-partitioner-plugin/pom.xml
+++ b/kettle-sdk-partitioner-plugin/pom.xml
@@ -10,15 +10,6 @@
   <artifactId>kettle-sdk-partitioner-plugin</artifactId>
   <version>8.3.0.0-SNAPSHOT</version>
   <name>Pentaho Data Integration SDK Partitioner Plugin</name>
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>xerces</groupId>
-        <artifactId>xercesImpl</artifactId>
-        <version>2.8.1</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.pentaho</groupId>

--- a/kettle-sdk-step-plugin/pom.xml
+++ b/kettle-sdk-step-plugin/pom.xml
@@ -10,15 +10,6 @@
   <artifactId>kettle-sdk-step-plugin</artifactId>
   <version>8.3.0.0-SNAPSHOT</version>
   <name>Pentaho Data Integration SDK Step Plugin</name>
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>xerces</groupId>
-        <artifactId>xercesImpl</artifactId>
-        <version>2.8.1</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.pentaho</groupId>


### PR DESCRIPTION
Do not merge before https://github.com/pentaho/maven-parent-poms/pull/120.
This is a series of PRs to update Apache Xerces to version 2.12.0.

@pentaho-lmartins 