### PR TITLE
[BACKLOG-27590] Upgrade to Karaf 4.2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ build-res/module-scripts/
 *.war
 *.ear
 *.iml
+.idea
 *.prefs
 *.classpath
 .idea/

--- a/kettle-sdk-embedding-samples/pom.xml
+++ b/kettle-sdk-embedding-samples/pom.xml
@@ -101,7 +101,17 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>3.0.1</version>
+      <version>3.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
[PDI-17667] Use of vulnerable component jetty 8.1.15, CVE-2017-9735, CVE-2017-7657 CVE-2015-2080
[PPP-4183] Use of Vulnerable Component: Multiple Jetty Components [Listed in Description] (CVE-2017-7656 | CVE-2017-7657 | CVE-2017-7658 | CVE-2015-2080 | CVE-2017-9735 )
[PDI-11851] Improve the jetty server version of Carte Server
[PPP-4402] Use of Vulnerable Component: jetty-server & jetty-util (CVE-2019-10246 | CVE-2019-10247)