### PR TITLE
[CLEANUP]  Carte now returns 400+ level error codes; previously only

### DIFF
--- a/kettle-sdk-embedding-samples/src/main/java/org/pentaho/di/sdk/samples/carte/GetJobStatusSample.java
+++ b/kettle-sdk-embedding-samples/src/main/java/org/pentaho/di/sdk/samples/carte/GetJobStatusSample.java
@@ -72,7 +72,7 @@ public class GetJobStatusSample extends AbstractSample {
     int code = httpResponse.getStatusLine().getStatusCode();
     String response = HttpClientUtil.responseToString( httpResponse );
     method.releaseConnection();
-    if ( code >= HttpStatus.SC_BAD_REQUEST ) {
+    if ( code >= HttpStatus.SC_INTERNAL_SERVER_ERROR ) {
       System.out.println( "Error occurred during getting job status." );
       return null;
     }


### PR DESCRIPTION
returned 200 for most requests (including job not found) and 500 for an error.