### PR TITLE
[BACKLOG-42947]-Upgrading jetty in pdi-sdk-plugins

### DIFF
--- a/kettle-sdk-embedding-samples/pom.xml
+++ b/kettle-sdk-embedding-samples/pom.xml
@@ -113,8 +113,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-servlet</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
[BACKLOG-42947]-Upgrading jetty in pdi-sdk-plugins

[BACKLOG-42947]: https://hv-eng.atlassian.net/browse/BACKLOG-42947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ