### PR TITLE
[BACKLOG-40823] - Upgrade the Tomcat version from current to 10.x.x with Java 17

### DIFF
--- a/kettle-sdk-embedding-samples/pom.xml
+++ b/kettle-sdk-embedding-samples/pom.xml
@@ -113,8 +113,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-servlet</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This pull request updates the dependencies in the `pom.xml` file to use newer versions of Jetty libraries compatible with EE10.

Dependency updates:

* [`kettle-sdk-embedding-samples/pom.xml`](diffhunk://#diff-a59f447c8fad1567d918d30d037de9dedf4dffa09956903e306112e9b519e80eL116-R117): Replaced `jetty-servlet` from `org.eclipse.jetty` with `jetty-ee10-servlet` from `org.eclipse.jetty.ee10` to align with EE10 standards.